### PR TITLE
Remove per-iteration debug print to prevent raid timeout 

### DIFF
--- a/src/main/java/me/unariginal/novaraids/managers/Raid.java
+++ b/src/main/java/me/unariginal/novaraids/managers/Raid.java
@@ -870,7 +870,6 @@ public class Raid {
             for (int i = 0; i < n - 1; i++) {
                 Map.Entry<UUID, Integer> e1 = leaderboard_list.get(i);
                 Map.Entry<UUID, Integer> e2 = leaderboard_list.get(i + 1);
-                System.out.println(e1.getKey() + " : " + e1.getValue() + " vs " + e2.getKey() + " : " + e2.getValue());
                 boolean duplicate = false;
                 for (int value : duplicates) {
                     if (e1.getValue() == value) {


### PR DESCRIPTION
## Changes

* Dropped the `System.out.println()` call inside the `get_damage_leaderboard()` sort loop due to it causing a server to potentially timeout if there are a large amount of participants.

## Future 
* Additionally, I would consider refactoring the loop statement, since the current setup is unnecessarily expensive.